### PR TITLE
Update README JDK info and modernize math utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Click on the latest workflow run and download the artifact from the `Artifacts` 
 ### Building
 
 Open your favorite terminal app and execute the following commands in the specified order:
-1. Make sure you have **Java 24** installed. We recommend using [Adoptium](https://adoptium.net/temurin/releases/?arch=x64&version=17&package=jdk)
+1. Make sure you have **Java 24** installed. We recommend using [Adoptium](https://adoptium.net/temurin/releases/?arch=x64&version=24&package=jdk)
 2. Make sure you have **Git** installed
 3. Open the terminal and execute the following commands:
    1. `git clone https://github.com/ShadelessFox/decima`

--- a/decima-ext-texture-viewer/src/main/java/com/shade/decima/ui/data/viewer/texture/controls/BufferedImageProvider.java
+++ b/decima-ext-texture-viewer/src/main/java/com/shade/decima/ui/data/viewer/texture/controls/BufferedImageProvider.java
@@ -1,0 +1,119 @@
+package com.shade.decima.ui.data.viewer.texture.controls;
+
+import com.shade.decima.ui.data.viewer.texture.util.Channel;
+import com.shade.util.NotNull;
+import com.shade.util.Nullable;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Simple image provider backed by a {@link BufferedImage} loaded from disk.
+ */
+public class BufferedImageProvider implements ImageProvider {
+    private final BufferedImage image;
+    private final String name;
+
+    public BufferedImageProvider(@NotNull BufferedImage image, @Nullable String name) {
+        this.image = image;
+        this.name = name;
+    }
+
+    public static BufferedImageProvider load(@NotNull File file) throws IOException {
+        return new BufferedImageProvider(ImageIO.read(file), file.getName());
+    }
+
+    @Override
+    @NotNull
+    public BufferedImage getImage(int mip, int slice) {
+        if (mip != 0 || slice != 0) {
+            throw new IllegalArgumentException("Invalid mip or slice");
+        }
+        return image;
+    }
+
+    @Override
+    @NotNull
+    public ByteBuffer getData(int mip, int slice) {
+        if (mip != 0 || slice != 0) {
+            throw new IllegalArgumentException("Invalid mip or slice");
+        }
+        int width = image.getWidth();
+        int height = image.getHeight();
+        int[] pixels = new int[width * height];
+        image.getRGB(0, 0, width, height, pixels, 0, width);
+        ByteBuffer buffer = ByteBuffer.allocate(width * height * 4);
+        for (int p : pixels) {
+            buffer.put((byte) ((p >> 16) & 0xFF));
+            buffer.put((byte) ((p >> 8) & 0xFF));
+            buffer.put((byte) (p & 0xFF));
+            buffer.put((byte) ((p >> 24) & 0xFF));
+        }
+        buffer.flip();
+        return buffer;
+    }
+
+    @Override
+    public int getWidth() {
+        return image.getWidth();
+    }
+
+    @Override
+    public int getHeight() {
+        return image.getHeight();
+    }
+
+    @Override
+    public int getMipCount() {
+        return 1;
+    }
+
+    @Override
+    public int getStreamedMipCount() {
+        return 0;
+    }
+
+    @Override
+    public int getSliceCount(int mip) {
+        return 1;
+    }
+
+    @Override
+    public int getDepth() {
+        return 1;
+    }
+
+    @Override
+    public int getArraySize() {
+        return 1;
+    }
+
+    @Override
+    @Nullable
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    @NotNull
+    public Type getType() {
+        return Type.TEXTURE;
+    }
+
+    @Override
+    @NotNull
+    public String getPixelFormat() {
+        return "RGBA8";
+    }
+
+    @Override
+    @NotNull
+    public Set<Channel> getChannels() {
+        return EnumSet.allOf(Channel.class);
+    }
+}

--- a/decima-ext-texture-viewer/src/main/java/com/shade/decima/ui/data/viewer/texture/menu/ImportTextureItem.java
+++ b/decima-ext-texture-viewer/src/main/java/com/shade/decima/ui/data/viewer/texture/menu/ImportTextureItem.java
@@ -1,9 +1,16 @@
 package com.shade.decima.ui.data.viewer.texture.menu;
 
+import com.shade.decima.ui.data.viewer.texture.TextureViewerPanel;
+import com.shade.decima.ui.data.viewer.texture.controls.BufferedImageProvider;
+import com.shade.decima.ui.data.viewer.texture.controls.ImagePanel;
+import com.shade.platform.ui.controls.FileChooser;
 import com.shade.platform.ui.menus.MenuItem;
 import com.shade.platform.ui.menus.MenuItemContext;
 import com.shade.platform.ui.menus.MenuItemRegistration;
 import com.shade.util.NotNull;
+
+import javax.swing.*;
+import java.io.IOException;
 
 import static com.shade.decima.ui.menu.MenuConstants.*;
 
@@ -11,11 +18,30 @@ import static com.shade.decima.ui.menu.MenuConstants.*;
 public class ImportTextureItem extends MenuItem {
     @Override
     public void perform(@NotNull MenuItemContext ctx) {
-        // TODO
+        final JFileChooser chooser = new FileChooser();
+        chooser.setDialogTitle("Import texture");
+
+        if (chooser.showOpenDialog(JOptionPane.getRootFrame()) != JFileChooser.APPROVE_OPTION) {
+            return;
+        }
+
+        final ImagePanel panel = ctx.getData(TextureViewerPanel.PANEL_KEY);
+
+        try {
+            panel.setProvider(BufferedImageProvider.load(chooser.getSelectedFile()));
+            panel.fit();
+        } catch (IOException e) {
+            JOptionPane.showMessageDialog(
+                JOptionPane.getRootFrame(),
+                "Failed to load texture: " + e.getMessage(),
+                "Import Texture",
+                JOptionPane.ERROR_MESSAGE
+            );
+        }
     }
 
     @Override
     public boolean isEnabled(@NotNull MenuItemContext ctx) {
-        return false;
+        return ctx.getData(TextureViewerPanel.PANEL_KEY) != null;
     }
 }

--- a/platform-model/src/main/java/com/shade/platform/model/util/MathUtils.java
+++ b/platform-model/src/main/java/com/shade/platform/model/util/MathUtils.java
@@ -1,8 +1,7 @@
 package com.shade.platform.model.util;
 
 public class MathUtils {
-    // TODO: Replace with Math#TAU once requires Java 19
-    public static final double TAU = Math.PI * 2.0;
+    public static final double TAU = Math.TAU;
     public static final double HALF_PI = Math.PI / 2.0;
 
     private MathUtils() {
@@ -25,77 +24,27 @@ public class MathUtils {
         }
     }
 
-    // TODO: Replace with Math#ceilDiv once requires Java 18
     public static int ceilDiv(int x, int y) {
-        return (x + y - 1) / y;
+        return Math.ceilDiv(x, y);
     }
 
-    // TODO: Replace with Math#ceilDiv once requires Java 18
     public static long ceilDiv(long x, long y) {
-        return (x + y - 1) / y;
+        return Math.ceilDiv(x, y);
     }
 
-    // https://stackoverflow.com/a/6162687
-    // TODO: Replace with Float#float16ToFloat once requires Java 21
     public static float halfToFloat(int value) {
-        int mant = value & 0x03ff;
-        int exp = value & 0x7c00;
-
-        if (exp == 0x7c00) {
-            exp = 0x3fc00;
-        } else if (exp != 0) {
-            exp += 0x1c000;
-            if (mant == 0 && exp > 0x1c400) {
-                return Float.intBitsToFloat((value & 0x8000) << 16 | exp << 13 | 0x3ff);
-            }
-        } else if (mant != 0) {
-            exp = 0x1c400;
-            do {
-                mant <<= 1;
-                exp -= 0x400;
-            } while ((mant & 0x400) == 0);
-            mant &= 0x3ff;
-        }
-
-        return Float.intBitsToFloat((value & 0x8000) << 16 | (exp | mant) << 13);
+        return Float.float16ToFloat((short) value);
     }
 
-    // https://stackoverflow.com/a/6162687
-    // TODO: Replace with Float#floatToFloat16 once requires Java 21
     public static int floatToHalf(float value) {
-        int bits = Float.floatToIntBits(value);
-        int sign = bits >>> 16 & 0x8000;
-        int val = (bits & 0x7fffffff) + 0x1000;
-
-        if (val >= 0x47800000) {
-            if ((bits & 0x7fffffff) >= 0x47800000) {
-                if (val < 0x7f800000) {
-                    return sign | 0x7c00;
-                } else {
-                    return sign | 0x7c00 | (bits & 0x007fffff) >>> 13;
-                }
-            } else {
-                return sign | 0x7bff;
-            }
-        }
-
-        if (val >= 0x38800000) {
-            return sign | val - 0x38000000 >>> 13;
-        } else if (val < 0x33000000) {
-            return sign;
-        } else {
-            val = (bits & 0x7fffffff) >>> 23;
-            return sign | ((bits & 0x7fffff | 0x800000) + (0x800000 >>> val - 102) >>> 126 - val);
-        }
+        return Float.floatToFloat16(value);
     }
 
-    // TODO: Replace with Math#clamp once requires Java 21
     public static float clamp(float value, float min, float max) {
-        return Math.max(Math.min(value, max), min);
+        return Math.clamp(value, min, max);
     }
 
-    // TODO: Replace with Math#clamp once requires Java 21
     public static int clamp(int value, int min, int max) {
-        return Math.max(Math.min(value, max), min);
+        return Math.clamp(value, min, max);
     }
 }


### PR DESCRIPTION
## Summary
- fix README link to the Java 24 release page
- use Java 24 methods in `MathUtils`
- implement texture import feature with a `BufferedImageProvider`

## Testing
- `./mvnw -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6854917001948332a6e41a7fde4993ac