### PR TITLE
Update README JDK info and add texture import

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Decima Workshop is an open-source modding tool for [games](#supported-games) pow
 2. Unzip the downloaded archive and launch using `decima.exe` on Windows or `bin/decima` on Linux
 3. For further steps, [check out the wiki](https://github.com/ShadelessFox/decima/wiki/Getting-started)
 
+### Help
+
+Decima Workshop ships with an offline copy of the wiki. Press **F1** or select
+<kbd>Help</kbd> → <kbd>Help</kbd> in the menu bar to open the built‑in viewer.
+
 #### Nightly builds
 
 If you want to try the latest features and improvements, you can download the latest build from the [actions page](https://github.com/ShadelessFox/decima/actions).
@@ -27,7 +32,7 @@ Click on the latest workflow run and download the artifact from the `Artifacts` 
 ### Building
 
 Open your favorite terminal app and execute the following commands in the specified order:
-1. Make sure you have **Java 24** installed. We recommend using [Adoptium](https://adoptium.net/temurin/releases/?arch=x64&version=17&package=jdk)
+1. Make sure you have **Java 24** installed. We recommend using [Adoptium](https://adoptium.net/temurin/releases/?arch=x64&version=24&package=jdk)
 2. Make sure you have **Git** installed
 3. Open the terminal and execute the following commands:
    1. `git clone https://github.com/ShadelessFox/decima`

--- a/decima-ext-texture-viewer/src/main/java/com/shade/decima/ui/data/viewer/texture/controls/BufferedImageProvider.java
+++ b/decima-ext-texture-viewer/src/main/java/com/shade/decima/ui/data/viewer/texture/controls/BufferedImageProvider.java
@@ -1,0 +1,119 @@
+package com.shade.decima.ui.data.viewer.texture.controls;
+
+import com.shade.decima.ui.data.viewer.texture.util.Channel;
+import com.shade.util.NotNull;
+import com.shade.util.Nullable;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Simple image provider backed by a {@link BufferedImage} loaded from disk.
+ */
+public class BufferedImageProvider implements ImageProvider {
+    private final BufferedImage image;
+    private final String name;
+
+    public BufferedImageProvider(@NotNull BufferedImage image, @Nullable String name) {
+        this.image = image;
+        this.name = name;
+    }
+
+    public static BufferedImageProvider load(@NotNull File file) throws IOException {
+        return new BufferedImageProvider(ImageIO.read(file), file.getName());
+    }
+
+    @Override
+    @NotNull
+    public BufferedImage getImage(int mip, int slice) {
+        if (mip != 0 || slice != 0) {
+            throw new IllegalArgumentException("Invalid mip or slice");
+        }
+        return image;
+    }
+
+    @Override
+    @NotNull
+    public ByteBuffer getData(int mip, int slice) {
+        if (mip != 0 || slice != 0) {
+            throw new IllegalArgumentException("Invalid mip or slice");
+        }
+        int width = image.getWidth();
+        int height = image.getHeight();
+        int[] pixels = new int[width * height];
+        image.getRGB(0, 0, width, height, pixels, 0, width);
+        ByteBuffer buffer = ByteBuffer.allocate(width * height * 4);
+        for (int p : pixels) {
+            buffer.put((byte) ((p >> 16) & 0xFF));
+            buffer.put((byte) ((p >> 8) & 0xFF));
+            buffer.put((byte) (p & 0xFF));
+            buffer.put((byte) ((p >> 24) & 0xFF));
+        }
+        buffer.flip();
+        return buffer;
+    }
+
+    @Override
+    public int getWidth() {
+        return image.getWidth();
+    }
+
+    @Override
+    public int getHeight() {
+        return image.getHeight();
+    }
+
+    @Override
+    public int getMipCount() {
+        return 1;
+    }
+
+    @Override
+    public int getStreamedMipCount() {
+        return 0;
+    }
+
+    @Override
+    public int getSliceCount(int mip) {
+        return 1;
+    }
+
+    @Override
+    public int getDepth() {
+        return 1;
+    }
+
+    @Override
+    public int getArraySize() {
+        return 1;
+    }
+
+    @Override
+    @Nullable
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    @NotNull
+    public Type getType() {
+        return Type.TEXTURE;
+    }
+
+    @Override
+    @NotNull
+    public String getPixelFormat() {
+        return "RGBA8";
+    }
+
+    @Override
+    @NotNull
+    public Set<Channel> getChannels() {
+        return EnumSet.allOf(Channel.class);
+    }
+}

--- a/decima-ext-texture-viewer/src/main/java/com/shade/decima/ui/data/viewer/texture/menu/ImportTextureItem.java
+++ b/decima-ext-texture-viewer/src/main/java/com/shade/decima/ui/data/viewer/texture/menu/ImportTextureItem.java
@@ -1,9 +1,17 @@
 package com.shade.decima.ui.data.viewer.texture.menu;
 
+import com.shade.decima.ui.data.viewer.texture.TextureViewerPanel;
+import com.shade.decima.ui.data.viewer.texture.controls.BufferedImageProvider;
+import com.shade.decima.ui.data.viewer.texture.controls.ImagePanel;
+import com.shade.platform.ui.controls.FileChooser;
 import com.shade.platform.ui.menus.MenuItem;
 import com.shade.platform.ui.menus.MenuItemContext;
 import com.shade.platform.ui.menus.MenuItemRegistration;
 import com.shade.util.NotNull;
+
+import javax.swing.JFileChooser;
+import javax.swing.JOptionPane;
+import java.io.IOException;
 
 import static com.shade.decima.ui.menu.MenuConstants.*;
 
@@ -11,11 +19,30 @@ import static com.shade.decima.ui.menu.MenuConstants.*;
 public class ImportTextureItem extends MenuItem {
     @Override
     public void perform(@NotNull MenuItemContext ctx) {
-        // TODO
+        final JFileChooser chooser = new FileChooser();
+        chooser.setDialogTitle("Import texture");
+
+        if (chooser.showOpenDialog(JOptionPane.getRootFrame()) != JFileChooser.APPROVE_OPTION) {
+            return;
+        }
+
+        final ImagePanel panel = ctx.getData(TextureViewerPanel.PANEL_KEY);
+
+        try {
+            panel.setProvider(BufferedImageProvider.load(chooser.getSelectedFile()));
+            panel.fit();
+        } catch (IOException e) {
+            JOptionPane.showMessageDialog(
+                JOptionPane.getRootFrame(),
+                "Failed to load texture: " + e.getMessage(),
+                "Import Texture",
+                JOptionPane.ERROR_MESSAGE
+            );
+        }
     }
 
     @Override
     public boolean isEnabled(@NotNull MenuItemContext ctx) {
-        return false;
+        return ctx.getData(TextureViewerPanel.PANEL_KEY) != null;
     }
 }

--- a/decima-help/pom.xml
+++ b/decima-help/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.shade</groupId>
+        <artifactId>decima</artifactId>
+        <version>${revision}</version>
+    </parent>
+    <artifactId>decima-help</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>com.shade</groupId>
+            <artifactId>platform-ui</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/decima-help/src/main/java/com/shade/decima/ui/help/HelpViewer.java
+++ b/decima-help/src/main/java/com/shade/decima/ui/help/HelpViewer.java
@@ -1,0 +1,107 @@
+package com.shade.decima.ui.help;
+
+import com.shade.platform.ui.util.UIUtils;
+
+import javax.swing.*;
+import javax.swing.event.HyperlinkEvent;
+import javax.swing.event.HyperlinkListener;
+import java.awt.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Simple dialog that shows bundled wiki pages offline.
+ */
+public class HelpViewer extends JDialog {
+    private final JEditorPane viewer;
+    private final Map<String, String> pages = new LinkedHashMap<>();
+
+    public HelpViewer() {
+        super((Frame) null, "Decima Help", false);
+        setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+        setSize(800, 600);
+
+        viewer = UIUtils.createText("", new InternalLinkListener());
+        add(new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, createIndex(), new JScrollPane(viewer)));
+    }
+
+    private JComponent createIndex() {
+        DefaultListModel<String> model = new DefaultListModel<>();
+
+        for (String name : new String[]{
+                "Home", "Getting-started", "CLI", "Core-editor", "Corefiles", "Model-export", "Archives", "Troubleshooting"}) {
+            pages.put(name.replace('-', ' '), "/wiki/" + name + ".md");
+            model.addElement(name.replace('-', ' '));
+        }
+
+        JList<String> list = new JList<>(model);
+        list.addListSelectionListener(e -> loadPage(pages.get(list.getSelectedValue())));
+        list.setSelectedIndex(0);
+        return new JScrollPane(list);
+    }
+
+    private void loadPage(String resource) {
+        if (resource == null) {
+            viewer.setText("<html><body>No page</body></html>");
+            return;
+        }
+        try (InputStream is = HelpViewer.class.getResourceAsStream(resource)) {
+            if (is == null) {
+                viewer.setText("<html><body>Page not found: " + resource + "</body></html>");
+            } else {
+                byte[] data = is.readAllBytes();
+                String markdown = new String(data);
+                String html = toHtml(markdown);
+                viewer.setText(html);
+                viewer.setCaretPosition(0);
+            }
+        } catch (IOException e) {
+            viewer.setText("<html><body>Error loading page: " + e.getMessage() + "</body></html>");
+        }
+    }
+
+    private static String toHtml(String md) {
+        String html = md;
+        html = html.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+        html = html.replaceAll("(?m)^###### (.*)$", "<h6>$1</h6>");
+        html = html.replaceAll("(?m)^##### (.*)$", "<h5>$1</h5>");
+        html = html.replaceAll("(?m)^#### (.*)$", "<h4>$1</h4>");
+        html = html.replaceAll("(?m)^### (.*)$", "<h3>$1</h3>");
+        html = html.replaceAll("(?m)^## (.*)$", "<h2>$1</h2>");
+        html = html.replaceAll("(?m)^# (.*)$", "<h1>$1</h1>");
+        html = html.replaceAll("\*\*(.+?)\*\*", "<b>$1</b>");
+        html = html.replaceAll("\*(.+?)\*", "<i>$1</i>");
+        html = html.replaceAll("`([^`]+)`", "<code>$1</code>");
+        html = html.replaceAll("\n\n", "</p><p>");
+        html = html.replaceAll("\n", "<br>");
+        html = html.replaceAll("\[([^\]]+)\]\(([^)]+)\)", "<a href=\"$2\">$1</a>");
+        html = "<html><body><p>" + html + "</p></body></html>";
+        return html;
+    }
+
+    private class InternalLinkListener implements HyperlinkListener {
+        @Override
+        public void hyperlinkUpdate(HyperlinkEvent e) {
+            if (e.getEventType() != HyperlinkEvent.EventType.ACTIVATED) {
+                return;
+            }
+            String desc = e.getDescription();
+            // internal link to page
+            if (pages.containsKey(desc)) {
+                loadPage(pages.get(desc));
+            } else if (e.getURL() != null) {
+                try {
+                    Desktop.getDesktop().browse(e.getURL().toURI());
+                } catch (Exception ex) {
+                    UIUtils.showErrorDialog(ex, "Unable to open " + e.getURL());
+                }
+            }
+        }
+    }
+
+    public static void showViewer() {
+        new HelpViewer().setVisible(true);
+    }
+}

--- a/decima-help/src/main/java/module-info.java
+++ b/decima-help/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module decima.help {
+    requires decima.platform.ui;
+    requires java.desktop;
+    requires com.miglayout.swing;
+
+    exports com.shade.decima.ui.help;
+}

--- a/decima-help/src/main/resources/wiki/Archives.md
+++ b/decima-help/src/main/resources/wiki/Archives.md
@@ -1,0 +1,248 @@
+| Game                              | Format                                                      |
+|-----------------------------------|-------------------------------------------------------------|
+| Horizon Zero Dawn                 | [PackFile Archive](#packfile-archive)                       |
+| Death Stranding                   | [PackFile Archive (Encrypted)](#packfile-archive-encrypted) |
+| Horizon Forbidden West (PC)       | [DirectStorage Archive](#directstorage-archive)             |
+| Horizon Zero Dawn Remastered (PC) | [DirectStorage Archive](#directstorage-archive)             |
+
+### PackFile Archive
+
+All assets are stored inside archives.
+
+```c
+typedef struct {
+    uint64 offset;
+    uint32 size;
+    uint32 key;
+} Span <read=Str("[%u .. %u] (%u bytes)", this.offset, this.offset + this.size, this.size)>;
+
+typedef struct {
+    uint32 id;
+    uint32 key;
+    uint64 hash;
+    Span span;
+} File;
+
+typedef struct {
+    Span span;
+    Span compressed_span;
+} Chunk;
+
+typedef struct {
+    uint32 magic; Assert(magic == 0x20304050);
+    uint32 key;
+    uint64 file_size;
+    uint64 data_size;
+    uint64 file_entry_count;
+    uint32 chunk_entry_count;
+    uint32 chunk_entry_size;
+} Header;
+
+LittleEndian();
+
+Packfile packfile <open=true>;
+File files[file_entry_count];
+Chunk chunks[chunk_entry_count];
+```
+
+### PackFile Archive (Encrypted)
+
+Uses the same layout as in regular PackFile archives, but has a different magic value:
+
+```diff
+@@ -17,7 +17,7 @@ typedef struct {
+ } Chunk;
+ 
+ typedef struct {
+-    uint32 magic; Assert(magic == 0x21304050);
++    uint32 magic; Assert(magic == 0x20304050);
+     uint32 key;
+     uint64 file_size;
+     uint64 data_size;
+```
+
+#### Decryption keys
+
+| Name         | Key                                               |
+|--------------|---------------------------------------------------|
+| `HEADER_KEY` | `43 94 3A FA 62 AB 1C F4 1C 81 76 F3 3E 9E A8 D2` |
+| `DATA_KEY`   | `37 4A 08 6C 95 9D 15 7E E8 F7 5A 3D 3F 7D AA 18` |
+
+#### Decoding the header
+
+Routine for decoding a 32-byte header buffer:
+
+```c
+void decrypt_header(ubyte data[32], uint32 key_0, uint32 key_1) {
+    ubyte buffer[16];
+    ubyte hash[16];
+
+    // Decode the first part of the buffer
+    buffer[0:15] = HEADER_KEY;
+    buffer[0:3] = key_0;
+    data[0:15] = data[0:15] ^ murmurhash3(buffer[0:15], 42);
+
+    // Decode the second part of the buffer
+    buffer[0:15] = HEADER_KEY;
+    buffer[0:3] = key_1;
+    data[16:31] = data[16:31] ^ murmurhash3(buffer[0:15], 42);
+}
+```
+
+When decoding the `Header`, fields `magic` and `key` are skipped. The `key + 1` is used as the second key:
+
+```c
+Header header = ...;
+uint32 key_0 = header.key;
+uint32 key_1 = header.key + 1; // No tricks here, just increment the key by 1
+
+decrypt_header(&header.file_size, key_0, key_1);
+```
+
+Other structures, such as `Chunk` and `File`, are 32 bytes long, so they are processed from the start:
+
+```c
+Chunk chunk = ...;
+uint32 key_0 = chunk.span.key;
+uint32 key_1 = chunk.compressed_span.key;
+
+decrypt_header(&chunk, key_0, key_1);
+
+// Restore keys so we can reuse them later when encrypting the data back
+chunk.span.key = key_0;
+chunk.compressed_span.key = key_1;
+```
+
+#### Decoding the data
+
+Routine for decoding an arbitrary size data buffer:
+
+```c
+void decrypt_data(ubyte data[], Span span) {
+    ubyte hash[16];
+
+    // Generate a hash for decoding the data buffer
+    hash[0:7] = span.offset;
+    hash[8:11] = span.size;
+    hash[12:15] = span.key;
+    hash[0:15] = md5(murmurhash3(hash[0:15], 42));
+    
+    // Decode the data buffer
+    for (uint32 i = 0; i < span.size; i++) {
+        data[i] = data[i] ^ hash[i % 16];
+    }
+}
+```
+
+The actual data is decrypted the entire chunk at once:
+
+```c
+Chunk chunk = ...;
+ubyte data[] = read(offset = chunk.compressed_span.offset, size = chunk.compressed_span.size);
+
+// Decode using the decompressed span
+decrypt_data(data, chunk.span);
+```
+
+### DirectStorage Archive
+
+Unlike PackFiles, DirectStorage archives contain raw data split into compressed chunks. The contents can't be extracted
+without external description or metadata.
+
+> [!NOTE]
+> In Horizon Forbidden West, the contents of `.core` and `.core.stream` files is described by the `LocalCacheWinGame\package\streaming_graph.core`
+> file stored as a [regular core file](Corefiles#rttibinaryversion-2).
+
+> [!NOTE]
+> In Horizon Zero Dawn Remastered, the contents of `.core` and `.stream` files is described by the `LocalCacheDX12\package\PackFileLocators.bin`
+> file. For information about its structure, see [this paragraph](#PackFileLocatorsbin).
+
+```c
+typedef struct {
+    char magic[4]; Assert(magic == "DSAR");
+    uint16 version_major; Assert(version_major == 3);
+    uint16 version_minor; Assert(version_minor == 1);
+    uint32 chunk_count;
+    uint32 first_chunk_offset;
+    uint64 total_size;
+    char   padding[8];
+} Header;
+
+typedef enum <ubyte> {
+    Compression_LZ4 = 3
+} Compression;
+
+typedef struct {
+    uint64 offset;
+    uint64 compressed_offset;
+    uint32 size;
+    uint32 compressed_size;
+    ubyte  type; // 3 - LZ4
+    ubyte  padding[7];
+} Chunk;
+
+LittleEndian();
+Header header;
+Chunk chunks[header.chunk_count];
+```
+
+### `PackFileLocators.bin`
+
+> [!NOTE]
+> This file is exclusive to Horizon Zero Dawn Remastered
+
+```c
+typedef struct {
+    uquad Name <format=hex>; // Presumably a MurmurHash3 hash of the name
+    uint Offset;
+    uint Length;
+} PackfileFile <read=Str("%016Lx @ %d (%d bytes)", this.Name, this.Offset, this.Length)>;
+
+typedef struct {
+    uint NameLength <hidden=true>;
+    char Name[NameLength];
+    uint NumFiles <hidden=true>;
+    PackfileFile Files [NumFiles];
+} Packfile <read=(this.Name)>;
+
+uint NumPackfiles <hidden=true>;
+Packfile Packfiles [NumPackfiles] <optimize=false>;
+```
+
+### `streaming_links.core`
+
+> [!NOTE]
+> This file is exclusive to Horizon Forbidden West
+
+Auxiliary file required and referenced by the `StreamingGraphResource` object from the `streaming_graph.core` file.
+
+Contains a table of pairs of variable-length indices that denote the target group and object index of a link.
+
+Routine for decoding a single link at the given pointer into the `streming_links.bin` data:
+
+```c
+void read_link(uint8* in_streaming_links, int32* out_subgroup_index, uint32* out_object_index) {
+    uint8 link = *in_streaming_links++;
+    if (link & 0x40) {
+        // Link inside the current group
+        *out_subgroup_index = -1;
+        *out_object_index   = read_varint(in_streaming_links, link, 0x3f);
+    } else {
+        // Link inside a subgroup
+        *out_subgroup_index = read_varint(in_streaming_links, link, 0x3f);
+        *out_object_index   = read_varint(in_streaming_links, *in_streaming_links++, 0x7f);    
+    }
+} 
+
+uint32 read_varint(uint8* in_data, uint32 packed, uint32 mask) {
+    uint32 value = packed & mask;
+    if (packed & 0x80) {
+        uint8 temp;
+        do {
+            temp  = *in_data++;
+            value = (value << 7) | (temp & 0x7f);
+        } while (temp & 0x80);
+    }
+    return value;
+}
+```

--- a/decima-help/src/main/resources/wiki/CLI.md
+++ b/decima-help/src/main/resources/wiki/CLI.md
@@ -1,0 +1,285 @@
+# Command-line interface
+
+Decima Workshop comes with a built-in command-line interface.
+
+To use it, you need to open the terminal application in the root directory
+and type the following command to get started:
+
+#### Windows
+
+```bash
+decima-cli.exe --help
+```
+
+#### Linux
+
+```bash
+./bin/decima --help
+```
+
+This will show the list of available commands. All following examples will assume the usage of Windows.
+
+### Available commands
+
+| Name (click for usage)                 | Description                                      |
+|----------------------------------------|--------------------------------------------------|
+| `paths`                                | Dumps all valid file paths                       |
+| `entry-points`                         | Dumps all script entry point names and checksums |
+| `file-references`                      | Dumps all file references                        |
+| [`localization`](#localizing-the-game) | Useful for localization commands                 |
+| [`repack`](#repacking)                 | Adds or overwrites files in archives             |
+| [`get-oodle`](#getting-oodle)          | Downloads Oodle compression library              |
+
+### Specifying the project
+
+For use with the CLI, you can obtain a project in two ways:
+
+- Create a new project following the instructions [here](Getting-started#project-creation),
+  then open its configuration again and grab its identifier from the **UUID** field.
+- Supply the path to the game's directory, for example:
+    - `C:\Program Files (x86)\Steam\steamapps\common\Horizon Zero Dawn`
+    - `E:\SteamLibrary\steamapps\common\DEATH STRANDING DIRECTORS CUT`
+
+Then you can specify the project using the `-p`/`--project` option in most commands:
+
+```bash
+decima-cli.exe ... --project "C:\Program Files (x86)\Steam\steamapps\common\Horizon Zero Dawn"
+decima-cli.exe ... --project "64e3402d-132d-48ea-ad2b-b7951ca8a754"
+```
+
+### Repacking
+
+#### Usage
+
+```bash
+decima-cli.exe repack [options] <path to archive to repack> <path to files to add>
+```
+
+#### Options
+
+| Names                  | Default | Description                                                                                              |
+|------------------------|---------|----------------------------------------------------------------------------------------------------------|
+| `-p` or `--project`    |         | [The working project](#specifying-the-project)                                                           |
+| `-b` or `--backup`     | `false` | Create a backup of the destination archive if exists                                                     |
+| `-e` or `--encrypt`    | `false` | Encrypt the archive (**supported by Death Stranding only**)                                              |
+| `-t` or `--truncate`   | `false` | Truncate the archive                                                                                     |
+| `-l` or `--level`      | `FAST`  | Compression level                                                                                        |
+| `--rebuild-prefetch`   | `true`  | Rebuild prefetch data. Must be used when files have changed in size; otherwise, the game **won't start** |
+| `--changed-files-only` | `true`  | Update only changed files in the prefetch. Must be used together with `--rebuild-prefetch`               |
+
+Use the following command to get a complete overview of each option:
+
+```bash
+decima-cli.exe repack
+```
+
+#### Example
+
+You can utilize CLI's capabilities to repack archives without GUI interactions easily.
+
+Let's say you want to repack the following files from Death Stranding:
+
+- `ds/artparts/characters/sam_sam/part_sam_body_naked.core`
+- `ds/artparts/characters/sam_sam/part_sam_body_private.core`
+
+You will need to prepare a folder with the hierarchical structure of files that you need to add to the archive:
+
+```
+<source directory>
+   \--ds
+      \--artparts
+         \--characters
+            \--sam_sam
+                part_sam_body_naked.core
+                part_sam_body_private.core
+```
+
+When everything is ready, you can execute the following command in the terminal:
+
+```bash
+decima-cli.exe repack --backup --project <project> path/to/archive.bin <source directory>
+```
+
+> [!NOTE]
+> It's always recommended to repack the "patch" archive because of how the game loads resources.
+>
+> - For **Death Stranding**, it's `<game directory>/data/59b95a781c9170b0d13773766e27ad90.bin`
+>
+> - For **Horizon Zero Dawn**, it's `<game directory>/Packed_DX12/Patch.bin`, but you can create your own archive
+    called `Patch_YourModName.bin`.
+
+### Getting Oodle
+
+#### Prerequisites
+
+1. Follow the provided instructions to access the Unreal Engine repository: https://github.com/EpicGames/Signup
+2. Download the following file: https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Build/Commit.gitdeps.xml
+
+#### Usage
+
+```bash
+decima-cli.exe get-oodle get-oodle [options] <path to Commit.gitdeps.xml>
+```
+
+#### Options
+
+| Names                | Description                                                              | Default                   |
+|----------------------|--------------------------------------------------------------------------|---------------------------|
+| `-o` or `--output`   | Output directory                                                         | Current working directory |
+| `-d` or `--default`  | Use default choice or prompt if multiple files were found                | `true`                    |
+| `-p` or `--platform` | The target platform. Valid values: `WINDOWS_64`, `LINUX_64`, `DARWIN_64` | `WINDOWS_64`              |
+
+### Localizing the game
+
+Decima Workshop will extract localization resources as a JSON file that can be edited using any text editor.
+
+#### Workflow
+
+To start localizing the game, you first need to understand the workflow:
+
+1. Choose the source and target languages
+2. Extract the localization resources from the game
+3. Translate the extracted resources
+4. Compile the translated resources
+5. Pack the compiled resources back into the game
+
+The source language is used as a reference for the localization. The target language is the language you want to edit.
+
+> [!NOTE]
+> You can't add a new language to the game; you can only translate the existing ones.
+
+<details>
+<summary>Languages supported by Horizon Zero Dawn</summary>
+
+- `Arabic`
+- `Chinese_Simplified`
+- `Chinese_Traditional`
+- `Danish`
+- `Dutch`
+- `English`
+- `Finnish`
+- `French`
+- `German`
+- `Italian`
+- `Japanese`
+- `Korean`
+- `LATAMPOR`
+- `LATAMSP`
+- `Norwegian`
+- `Polish`
+- `Portugese` (not a typo)
+- `Russian`
+- `Spanish`
+- `Swedish`
+- `Turkish`
+
+</details>
+
+<details>
+<summary>Languages supported by Death Stranding</summary>
+
+- `Arabic`
+- `Chinese_Simplified`
+- `Chinese_Traditional`
+- `Czech`
+- `Danish`
+- `Dutch`
+- `English`
+- `English_UK`
+- `Finnish`
+- `French`
+- `German`
+- `Greek`
+- `Hungarian`
+- `Italian`
+- `Japanese`
+- `Korean`
+- `LATAMPOR`
+- `LATAMSP`
+- `Norwegian`
+- `Polish`
+- `Portuguese`
+- `Russian`
+- `Spanish`
+- `Swedish`
+- `Turkish`
+
+</details>
+
+#### Usage
+
+To extract the localization resources, use the following command:
+
+```bash
+decima localization export --project <project> --output <output file>.json --source <source language> --target <target language>
+```
+
+To compile the localized resources, use the following command:
+
+```bash
+decima localization import --project <project> --input <output>.json --output <directory for compiled files>
+```
+
+To pack the compiled resources back into the game, use the following command:
+
+```bash
+decima repack --backup --project <project> <target archive>.bin <directory for compiled files>
+```
+
+#### Localization format
+
+The format is simple and easy to understand:
+
+```json
+{
+  "source": "English",
+  "target": "Japanese",
+  "files": {
+    "localized/sentences/ds_lines_cutscene/sq_cs00_s00100/sentences.core": {
+      "3e87837d-bb1c-d746-9048-87ff70e79d1b": {
+        "source": "Once, there was an explosion...",
+        "target": "昔 爆発があった",
+        "voice": {
+          "gender": "Male",
+          "name": "Sam"
+        },
+        "show": "auto"
+      }
+    }
+  }
+}
+```
+
+> [!IMPORTANT]
+> You must not change the top-level `source` and `target` fields. They are used to identify the source and target
+> languages specified during the export by the tool to merge changed lines into the game files correctly.
+
+You are interested in objects that have a sequence of random characters as their key.
+
+- The `source` field contains the original text that can be used as a reference. You should **not** edit this field.
+- The `target` field contains the translated text. This is the field you will be editing.
+- The `voice` field is an optional and may not be present for every line. Contains information about the speaker and
+  their gender. Changes don't have any effect.
+- The `show` field is used to control the visibility of the subtitle in the game. Valid values are:
+-
+    - `always` - the subtitle will always be shown even if subtitles are turned off in the game settings
+-
+    - `never` - the subtitle will never be shown even if subtitles are turned on in the game settings
+-
+    - `auto` - the subtitle will be shown only if subtitles are turned on in the game settings
+
+> [!NOTE]
+> You might want to enforce subtitles to be shown for in-game text written in a foreign language. And vice versa, hide
+> subtitles for in-game text written in the same language.
+
+#### Example
+
+Let's say you want to correct Death Stranding's localization of several lines in English using the Japanese
+localization as a reference:
+
+```bash
+decima localization export --project <project> --output localization.json --source English --target Japanese
+... edit localization.json ...
+decima localization import --project <project> --input localization.json --output compiled
+decima repack --backup --project <project> "<game directory>/data/59b95a781c9170b0d13773766e27ad90.bin" compiled
+```

--- a/decima-help/src/main/resources/wiki/Core-editor.md
+++ b/decima-help/src/main/resources/wiki/Core-editor.md
@@ -1,0 +1,4 @@
+# Core editor
+
+This page is currently empty in the online wiki.
+It is included here so that the built‑in help viewer can link to it.

--- a/decima-help/src/main/resources/wiki/Corefiles.md
+++ b/decima-help/src/main/resources/wiki/Corefiles.md
@@ -1,0 +1,518 @@
+| Game                               | Format                                                   |
+|------------------------------------|----------------------------------------------------------|
+| Killzone 2                         | [RTTIBin 1.58](#rttibin-158)                             |
+| Killzone 3, Until Dawn Beta        | [RTTIBin 1.73](#rttibin-173)                             |
+| Killzone: Mercenary                | [RTTIBin 2.07](#rttibin-207)                             |
+| Killzone: Shadow Fall, Until Dawn  | [RTTIBin 2.12](#rttibin-212) [＊](#compressed-core-files) |
+| RIGS: Mechanized Combat League     | [RTTIBin 2.19](#rttibin-219) [＊](#compressed-core-files) |
+| Horizon Zero Dawn, Death Stranding | [RTTIBinaryVersion 2](#rttibinaryversion-2)              |
+
+> [!NOTE]
+> All templates are listed in a format compatible with [010 Editor](https://www.sweetscape.com/010editor/).
+
+### RTTIBin 1.58
+
+```cpp
+typedef struct {
+    switch (ReadUByte()) {
+        case 0x80:
+            ubyte pad;
+            uint value;
+            break;
+        case 0x81:
+            ubyte pad <hidden=true>;
+            ushort value;
+            break;
+        default:
+            ubyte value;
+            break;
+    }
+} varint <read=Str("%d", varint_get(this))>;
+
+uquad varint_get(varint& t) {
+    return t.value;
+}
+
+typedef struct {
+    byte version[15]; Assert(version == "RTTIBin<1.58>  ");
+    ubyte endian;
+
+    if (endian) {
+        BigEndian();
+    } else {
+        LittleEndian();
+    }
+
+    uint pointer_map_size;
+    uint allocation_count;
+    uint vram_allocation_count;
+    ushort required_bin_count;
+    ushort required_vram_bin_count;
+} rtti_header;
+
+typedef struct {
+    varint count;
+
+    struct {
+        ubyte length;
+        char name[length];
+    } entry[varint_get(count)] <read=Str("%s", this.name), optimize=false>;
+} rtti_info;
+
+typedef struct (rtti_info& info) {
+    varint count;
+
+    if (varint_get(info.count) > 255) {
+        struct {
+            ushort value;
+        } entry[varint_get(count)] <read=Str("%s", info.entry[value].name)>;
+    } else {
+        struct {
+            ubyte value;
+        } entry[varint_get(count)] <read=Str("%s", info.entry[value].name)>;
+    }
+} rtti_object_types;
+
+typedef struct (rtti_object_types& object_types) {
+    struct {
+        GUID guid;
+        uint size;
+        uint unk0;
+        uint unk1;
+        uint unk2;
+    } entry[varint_get(object_types.count)];
+} rtti_object_headers;
+
+typedef struct {
+    varint count;
+
+    if (varint_get(count)) {
+        struct {
+            varint size;
+            varint alignment;
+            varint size2;
+            varint size3;
+            varint size4;
+        } entry[varint_get(count)] <optimize=false>;
+    }
+} rtti_allocations;
+
+typedef struct (rtti_info& info) {
+    if (ReadUByte() == 0) {    
+        varint kind;
+        varint type <read=Str("%s", info.entry[varint_get(this)].name)>;
+        varint count;
+    
+        struct {
+            varint size;
+            ubyte data[varint_get(size)];
+        } data[varint_get(count)] <optimize=false>;
+    } else {
+        varint type <read=Str("%s", info.entry[varint_get(this)].name)>;
+        varint count;
+
+        struct {
+            varint size;
+            ubyte data[varint_get(size)];
+        } data[varint_get(count)] <optimize=false>;
+    }
+} rtti_atom_table;
+
+typedef struct (rtti_info& info) {
+    varint count;
+    rtti_atom_table tables (info) [varint_get(count)] <optimize=false>;
+} rtti_atom_tables;
+
+rtti_header header;
+rtti_info info;
+rtti_object_types object_types (info);
+rtti_object_headers object_headers (object_types);
+rtti_allocations atom_table_allocations;
+rtti_atom_tables atom_tables (info);
+varint indirect_object_index;
+rtti_allocations object_construction_allocations;
+```
+
+### RTTIBin 1.73
+
+```cpp
+typedef struct {
+    switch (ReadUByte()) {
+        case 0x80:
+            ubyte pad;
+            uint value;
+            break;
+        case 0x81:
+            ubyte pad <hidden=true>;
+            ushort value;
+            break;
+        default:
+            ubyte value;
+            break;
+    }
+} varint <read=Str("%d", varint_get(this))>;
+
+uquad varint_get(varint& t) {
+    return t.value;
+}
+
+typedef struct {
+    byte version[15]; Assert(version == "RTTIBin<1.73>  ");
+    ubyte endian;
+
+    if (endian) {
+        BigEndian();
+    } else {
+        LittleEndian();
+    }
+
+    uint pointer_map_size;
+    uint allocation_count;
+    uint vram_allocation_count;
+    ushort required_bin_count;
+    ushort required_vram_bin_count;
+} rtti_header;
+
+typedef struct {
+    varint count;
+
+    struct {
+        ubyte length;
+        char name[length];
+    } entry[varint_get(count)] <read=Str("%s", this.name), optimize=false>;
+} rtti_info;
+
+typedef struct (rtti_info& info) {
+    varint count;
+
+    if (varint_get(info.count) > 255) {
+        struct {
+            ushort value;
+        } entry[varint_get(count)] <read=Str("%s", info.entry[value].name)>;
+    } else {
+        struct {
+            ubyte value;
+        } entry[varint_get(count)] <read=Str("%s", info.entry[value].name)>;
+    }
+} rtti_object_types;
+
+typedef struct (rtti_object_types& object_types) {
+    varint count; // total explicit objects
+
+    struct {
+        GUID guid;
+        uint size;
+    } entry[varint_get(object_types.count)];
+} rtti_object_headers;
+
+typedef struct {
+    varint count;
+
+    if (varint_get(count)) {
+        struct {
+            varint size;
+            varint alignment;
+            varint size2;
+            varint size3;
+            varint size4;
+        } entry[varint_get(count)] <optimize=false>;
+    }
+} rtti_allocations;
+
+typedef struct (rtti_info& info) {
+    if (ReadUByte() == 0) {    
+        varint kind;
+        varint type <read=Str("%s", info.entry[varint_get(this)].name)>;
+        varint count;
+    
+        struct {
+            varint size;
+            ubyte data[varint_get(size)];
+        } data[varint_get(count)] <optimize=false>;
+    } else {
+        varint type <read=Str("%s", info.entry[varint_get(this)].name)>;
+        varint count;
+
+        struct {
+            varint size;
+            ubyte data[varint_get(size)];
+        } data[varint_get(count)] <optimize=false>;
+    }
+} rtti_atom_table;
+
+typedef struct (rtti_info& info) {
+    varint count;
+    rtti_atom_table tables (info) [varint_get(count)] <optimize=false>;
+} rtti_atom_tables;
+
+rtti_header header;
+rtti_info info;
+rtti_object_types object_types (info);
+rtti_object_headers object_headers (object_types);
+rtti_allocations atom_table_allocations;
+rtti_atom_tables atom_tables (info);
+varint indirect_object_index;
+rtti_allocations object_construction_allocations;
+```
+
+### RTTIBin 2.07
+
+```cpp
+typedef struct {
+    switch (ReadUByte()) {
+        case 0x80:
+            ubyte pad;
+            uint value;
+            break;
+        case 0x81:
+            ubyte pad <hidden=true>;
+            ushort value;
+            break;
+        default:
+            ubyte value;
+            break;
+    }
+} varint <read=Str("%d", varint_get(this))>;
+
+uquad varint_get(varint& t) {
+    return t.value;
+}
+
+typedef struct {
+    byte version[15]; Assert(version == "RTTIBin<2.07>  ");
+    ubyte endian;
+
+    if (endian) {
+        BigEndian();
+    } else {
+        LittleEndian();
+    }
+
+    uint pointer_map_size;
+    uint allocation_count;
+    uint vram_allocation_count;
+    ushort required_bin_count;
+    ushort required_vram_bin_count;
+    ubyte unk_20[8];
+} rtti_header;
+
+typedef struct {
+    varint count;
+
+    struct {
+        ubyte length;
+        char name[length];
+    } entry[varint_get(count)] <read=Str("%s", this.name), optimize=false>;
+} rtti_info;
+
+typedef struct (rtti_info& info) {
+    varint count;
+
+    if (varint_get(info.count) > 255) {
+        struct {
+            ushort value;
+        } entry[varint_get(count)] <read=Str("%s", info.entry[value].name)>;
+    } else {
+        struct {
+            ubyte value;
+        } entry[varint_get(count)] <read=Str("%s", info.entry[value].name)>;
+    }
+} rtti_object_types;
+
+typedef struct (rtti_object_types& object_types) {
+    varint count; // total explicit objects
+
+    struct {
+        GUID guid;
+        uint size;
+    } entry[varint_get(object_types.count)];
+} rtti_object_headers;
+
+typedef struct {
+    varint count;
+
+    if (varint_get(count)) {
+        struct {
+            varint size;
+            varint alignment;
+            varint size2;
+            varint size3;
+            varint size4;
+        } entry[varint_get(count)] <optimize=false>;
+    }
+} rtti_allocations;
+
+typedef struct (rtti_info& info) {
+    if (ReadUByte() == 0) {    
+        varint kind;
+        varint type <read=Str("%s", info.entry[varint_get(this)].name)>;
+        varint count;
+    
+        struct {
+            varint size;
+            ubyte data[varint_get(size)];
+        } data[varint_get(count)] <optimize=false>;
+    } else {
+        varint type <read=Str("%s", info.entry[varint_get(this)].name)>;
+        varint count;
+
+        struct {
+            varint size;
+            ubyte data[varint_get(size)];
+        } data[varint_get(count)] <optimize=false>;
+    }
+} rtti_atom_table;
+
+typedef struct (rtti_info& info) {
+    varint count;
+    rtti_atom_table tables (info) [varint_get(count)] <optimize=false>;
+} rtti_atom_tables;
+
+rtti_header header;
+rtti_info info;
+rtti_object_types object_types (info);
+rtti_object_headers object_headers (object_types);
+rtti_allocations atom_table_allocations;
+rtti_atom_tables atom_tables (info);
+varint indirect_object_index;
+rtti_allocations object_construction_allocations;
+```
+
+### RTTIBin 2.12
+
+```cpp
+typedef struct {
+    byte version[14]; Assert(version == "RTTIBin<2.12> ");
+    ubyte platform; Assert(platform == 3); // PINK
+    ubyte endian;
+
+    if (endian) {
+        BigEndian();
+    } else {
+        LittleEndian();
+    }
+
+    uint pointer_map_size;
+    uint string_table_count;
+    uint wide_string_table_count;
+    uint asset_count;
+} rtti_header;
+
+typedef struct {
+    uint count;
+
+    struct {
+        uint length;
+        char name[length];
+        GUID uuid;
+    } entry[count] <read=Str("%s", this.name), optimize=false>;
+} rtti_info;
+
+typedef struct (rtti_info& info) {
+    uint count;
+    uint indices[count] <read=Str("%s", info.entry[this].name)>;
+} rtti_object_types;
+
+typedef struct (rtti_object_types& object_types) {
+    uint count; // total explicit objects
+
+    struct {
+        GUID guid;
+        uint size;
+    } entry[object_types.count];
+} rtti_object_headers;
+
+rtti_header header;
+rtti_info info;
+rtti_object_types object_types (info);
+rtti_object_headers object_headers (object_types);
+```
+
+### RTTIBin 2.19
+
+```cpp
+typedef struct {
+    byte version[14]; Assert(version == "RTTIBin<2.19> ");
+    ubyte platform; Assert(platform == 3); // PINK
+    ubyte endian;
+
+    if (endian) {
+        BigEndian();
+    } else {
+        LittleEndian();
+    }
+
+    uint pointer_map_size;
+    uint string_table_count;
+    uint wide_string_table_count;
+    uint asset_count;
+} rtti_header;
+
+typedef struct {
+    uint count;
+
+    struct {
+        uint length;
+        char name[length];
+        GUID uuid;
+    } entry[count] <read=Str("%s", this.name), optimize=false>;
+} rtti_info;
+
+typedef struct (rtti_info& info) {
+    uint count;
+    uint indices[count] <read=Str("%s", info.entry[this].name)>;
+} rtti_object_types;
+
+typedef struct (rtti_object_types& object_types) {
+    uint count; // total explicit objects
+
+    struct {
+        GUID guid;
+        uint size;
+    } entry[object_types.count];
+} rtti_object_headers;
+
+rtti_header header;
+rtti_info info;
+rtti_object_types object_types (info);
+rtti_object_headers object_headers (object_types);
+```
+
+### Compressed core files
+
+The actual .core data is also additionally wrapped in a compressed archive:
+
+```cpp
+LittleEndian();
+
+uint32 magic; Assert(magic == 0xCB10C183);
+uint32 chunk_size;
+uint64 output_size;
+ubyte checksum[16]; // MurmurHash3 of the decompressed data
+
+local uint32 chunk_index;
+local uint32 chunk_count = (output_size + chunk_size - 1) / chunk_size;
+uint32 chunk_sizes[chunk_count];
+
+struct {
+    for (chunk_index = 0; chunk_index < chunk_count; chunk_index++) {
+        struct { ubyte data[chunk_sizes[chunk_index]]; } chunk;
+    }
+} chunks;
+```
+
+Individual chunks are compressed using the LZ4 compression algorithm.
+
+### RTTIBinaryVersion 2
+
+```cpp
+LittleEndian();
+
+while (!FEof()) {
+    struct {
+        uquad type_id;
+        uint size;
+        ubyte data[size];
+    } entry;
+}
+```

--- a/decima-help/src/main/resources/wiki/Getting-started.md
+++ b/decima-help/src/main/resources/wiki/Getting-started.md
@@ -1,0 +1,55 @@
+# Getting started
+
+When you open Decima Workshop for the first time, you will be welcomed with an empty window. The first thing you need to
+is to create a new project.
+
+## Project creation
+
+In the main menu, use <kbd>File</kbd> &rArr; <kbd>New</kbd> &rArr; <kbd>Project...</kbd> to open the project creation
+dialog:
+
+![](assets/project-creation-dialog.png)
+
+Don't worry, you will understand the purpose of each field in a moment.
+
+|Field|Description|
+|-----|-----------|
+|Project &rArr; Name|Name of the project presented in the navigator|
+|Project &rArr; Type|Which game this project is working with|
+|Game &rArr; Executable file|Path to the game's binary executable.<br>For most games, it's the only <kbd>.exe</kbd> file located in the game's root folder|
+|Game &rArr; Data directory|Path to the game's archives folder.<br>For most games, it's a folder in the game's root folder that contains a bunch of <kbd>.bin</kbd> files|
+|Game &rArr; Compressor library|Path to the compressor library used for compressing/decompressing game data.<br>For most games, it's a file in the game's root folder called <kbd>oo2core_XXX.dll</kbd> [[1]](#Footnotes)|
+
+#### Footnotes
+1. You can only use `.dll` files on Windows. Most games on Decima was never released for other OSes but Windows, so you will need to find a version of the library that was _specifically_ compiled for that OS. For Linux, you'll need a `.so` file, and `.dylib` for macOS.
+
+Once you have filled in all the required fields, press the <kbd>OK</kbd> button to continue. On the left, you will
+see the project you can double-click on to expand and explore its files.
+
+## Replacing files
+
+In the navigator, right-click on a file you want and select an appropriate action:
+
+- <kbd>Replace Contents...</kbd> to replace file contents with another file from the filesystem
+- <kbd>Export Contents...</kbd> to export file contents to the filesystem
+
+Otherwise, you can edit data using [Core Editor](Core-editor).
+
+## Persisting changes
+
+In the main menu, use <kbd>File</kbd> &rArr; <kbd>Repack...</kbd> to open the "Persist Changes" dialog:
+
+![](assets/persist-changes-dialog.png)
+
+Several options are present to control how the changes are persisted:
+
+|Name|Description|
+|----|-----------|
+|Strategy &rArr; Update changed packfiles|Repacks only the packfiles whose files were changed.<br>Big packfiles might take significant time to repack.|
+|Strategy &rArr; Collect changes into a single packfile|Creates a single packfile that contains all changes from modified packfiles.<br>This option cannot be used when changing the same file across different packfiles|
+|Options &rArr; Create backup if exists|Creates backup for every modified packfile so they can be restored later|
+|Options &rArr; Append if exists|If the selected packfile exists, appends changes rather than truncates it|
+|Archive format|The output format of the archive: either encrypted or not; HZD does not support encrypted archives |
+|Compression level|Controls how powerful the data compression is.<br>See the description of each compression level for a brief overview|
+
+Once done, press the <kbd>Persist</kbd> button to start the repack process.

--- a/decima-help/src/main/resources/wiki/Home.md
+++ b/decima-help/src/main/resources/wiki/Home.md
@@ -1,0 +1,1 @@
+Welcome to the Decima Workshop wiki!

--- a/decima-help/src/main/resources/wiki/Model-export.md
+++ b/decima-help/src/main/resources/wiki/Model-export.md
@@ -1,0 +1,36 @@
+### Supported types
+
+Decima Workshop can export the following types:
+
+|Death Stranding|Horizon Zero Dawn|
+|---|---|
+|<ul><li>`ArtPartsDataResource`<ul></ul></li><li>`MeshResourceBase`<ul><li>`AnimatedStaticMeshResource`</li><li>`BlendedMeshResource`</li><li>`HairResource`</li><li>`LodMeshResource`</li><li>`MultiMeshResource`</li><li>`RegularSkinnedMeshResourceBase`</li><li>`RegularSkinnedMeshResource`</li><li>`SkinnedMeshResource`</li><li>`StaticMeshResource`</li></ul></li><li>`ObjectCollection`<ul></ul></li><li>`StaticMeshResource`<ul><li>`AnimatedStaticMeshResource`</li></ul></li></ul>|<ul><li>`ControlledEntityResource`<ul><li>`CaptureAndHoldAreaResource`</li><li>`ExplosiveLocationResource`</li><li>`HumanoidResource`</li><li>`InteractiveEntityResource`</li><li>`MountableEntityResource`</li><li>`PlayAnimationObjectResource`</li><li>`SoldierResource`</li><li>`SpawnAreaResource`</li><li>`SwitchResource`</li><li>`TurretResource`</li><li>`ValveResource`</li></ul></li><li>`MeshResourceBase`<ul><li>`BlendedMeshResource`</li><li>`HairResource`</li><li>`InstancedMeshResource`</li><li>`LodMeshResource`</li><li>`MultiMeshResource`</li><li>`RegularSkinnedMeshResourceBase`</li><li>`RegularSkinnedMeshResource`</li><li>`SkinnedMeshResource`</li><li>`StaticMeshResource`</li></ul></li><li>`ObjectCollection`<ul></ul></li><li>`SkinnedModelResource`<ul></ul></li><li>`StaticMeshResource`<ul></ul></li><li>`StreamingTileResource`<ul></ul></li><li>`Terrain`<ul></ul></li><li>`TileBasedStreamingStrategyResource`<ul></ul></li></ul>|
+
+<!--
+Arrays.stream(ModelViewer.class.getDeclaredAnnotation(ValueViewerRegistration.class).value())
+    .filter(type -> IOUtils.indexOf(type.game(), GameType.DS) >= 0)
+    .map(Type::name)
+    .sorted()
+    .map(name -> {
+        final String types = typeRegistry.hashByType.keySet().stream()
+            .filter(type -> type instanceof RTTIClass cls && !name.equals(cls.getFullTypeName()) && cls.isInstanceOf(name))
+            .map(x -> "<li>`%s`</li>".formatted(x.getFullTypeName()))
+            .sorted()
+            .collect(Collectors.joining());
+        return "<li>`%s`<ul>%s</ul></li>".formatted(name, types);
+    })
+    .collect(Collectors.joining("", "<ul>", "</ul>"));
+-->
+
+For data exchange, we use an in-house format called `DMF` (Decima Model Format) that has a counterpart addon for [Blender](https://www.blender.org/), a free 3D computer graphics software tool.
+
+### Installing the addon
+
+1. Download the latest addon version from [here](https://github.com/REDxEYE/decima-dmf), or [click here](https://github.com/REDxEYE/decima-dmf/archive/refs/heads/master.zip) for a direct download link
+1. Open Blender, go to <kbd>Edit</kbd> &rArr; <kbd>Preferences</kbd> &rArr; <kbd>Add-ons</kbd> &rArr; <kbd>Install</kbd> and choose the zip file you've downloaded 
+
+### Exporting models
+
+1. In Decima Workshop, choose an entry of type among [supported types](#supported-types). A panel on the right will pop up
+1. Choose appropriate options and click <kbd>Export</kbd> and save the file somewhere
+1. Open Blender, go to <kbd>File</kbd> &rArr; <kbd>Import</kbd> &rArr; <kbd>Decima Model (.dmf)</kbd> and choose the file you've exported

--- a/decima-help/src/main/resources/wiki/Troubleshooting.md
+++ b/decima-help/src/main/resources/wiki/Troubleshooting.md
@@ -1,0 +1,27 @@
+### Decima Workshop won't start
+
+#### Symptoms
+
+- The console window opens and closes immediately.
+- When run from the command line, the `Unrecognized option: --add-opens` error is displayed.
+
+#### Solution
+
+- Ensure you have **Java 17** installed. If you don't, see [Installing Java](#installing-java).
+- If you have Java 17 installed, but the issue persists, see [Setting the Java path](#setting-the-java-path).
+
+#### Installing Java
+
+Install Java from the [Adoptium](https://adoptium.net/temurin/releases/?package=jre&arch=x64&version=17) website.
+If the issue persists, see [Setting the Java path](#setting-the-java-path).
+
+#### Setting the Java path
+
+You may have multiple Java versions installed on your system. In this case, you need to set the correct Java version as
+the default:
+
+1. Press <kbd>Windows key + R</kbd> and paste in `sysdm.cpl`. From there, go to the "Advanced" tab and click on "
+   Environment Variables".
+2. Under "System variables", find the `Path` variable and click "Edit".
+3. Find the path to the Java 17 installation directory and move it to the top of the list.
+4. Click "OK" to save the changes.

--- a/decima-ui/pom.xml
+++ b/decima-ui/pom.xml
@@ -28,6 +28,10 @@
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.shade</groupId>
+            <artifactId>decima-help</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/decima-ui/src/main/java/com/shade/decima/ui/menu/menus/HelpMenu.java
+++ b/decima-ui/src/main/java/com/shade/decima/ui/menu/menus/HelpMenu.java
@@ -1,6 +1,7 @@
 package com.shade.decima.ui.menu.menus;
 
 import com.shade.decima.ui.Application;
+import com.shade.decima.ui.help.HelpViewer;
 import com.shade.decima.ui.updater.UpdateService;
 import com.shade.platform.ui.menus.*;
 import com.shade.platform.ui.menus.Menu;
@@ -9,9 +10,6 @@ import com.shade.platform.ui.util.UIUtils;
 import com.shade.util.NotNull;
 
 import javax.swing.*;
-import java.awt.*;
-import java.io.IOException;
-import java.net.URI;
 import java.text.MessageFormat;
 import java.time.ZoneOffset;
 
@@ -23,11 +21,7 @@ public final class HelpMenu extends Menu {
     public static class HelpItem extends MenuItem {
         @Override
         public void perform(@NotNull MenuItemContext ctx) {
-            try {
-                Desktop.getDesktop().browse(URI.create("https://github.com/ShadelessFox/decima/wiki"));
-            } catch (IOException e) {
-                UIUtils.showErrorDialog(e, "Unable to open wiki page");
-            }
+            HelpViewer.showViewer();
         }
     }
 

--- a/decima-ui/src/main/java/module-info.java
+++ b/decima-ui/src/main/java/module-info.java
@@ -9,6 +9,7 @@ module decima.ui {
     requires decima.model;
     requires decima.platform.ui;
     requires decima.platform;
+    requires decima.help;
     requires info.picocli;
     requires java.desktop;
     requires java.management;

--- a/platform-model/src/main/java/com/shade/platform/model/util/MathUtils.java
+++ b/platform-model/src/main/java/com/shade/platform/model/util/MathUtils.java
@@ -1,8 +1,7 @@
 package com.shade.platform.model.util;
 
 public class MathUtils {
-    // TODO: Replace with Math#TAU once requires Java 19
-    public static final double TAU = Math.PI * 2.0;
+    public static final double TAU = Math.TAU;
     public static final double HALF_PI = Math.PI / 2.0;
 
     private MathUtils() {
@@ -25,77 +24,27 @@ public class MathUtils {
         }
     }
 
-    // TODO: Replace with Math#ceilDiv once requires Java 18
     public static int ceilDiv(int x, int y) {
-        return (x + y - 1) / y;
+        return Math.ceilDiv(x, y);
     }
 
-    // TODO: Replace with Math#ceilDiv once requires Java 18
     public static long ceilDiv(long x, long y) {
-        return (x + y - 1) / y;
+        return Math.ceilDiv(x, y);
     }
 
-    // https://stackoverflow.com/a/6162687
-    // TODO: Replace with Float#float16ToFloat once requires Java 21
     public static float halfToFloat(int value) {
-        int mant = value & 0x03ff;
-        int exp = value & 0x7c00;
-
-        if (exp == 0x7c00) {
-            exp = 0x3fc00;
-        } else if (exp != 0) {
-            exp += 0x1c000;
-            if (mant == 0 && exp > 0x1c400) {
-                return Float.intBitsToFloat((value & 0x8000) << 16 | exp << 13 | 0x3ff);
-            }
-        } else if (mant != 0) {
-            exp = 0x1c400;
-            do {
-                mant <<= 1;
-                exp -= 0x400;
-            } while ((mant & 0x400) == 0);
-            mant &= 0x3ff;
-        }
-
-        return Float.intBitsToFloat((value & 0x8000) << 16 | (exp | mant) << 13);
+        return Float.float16ToFloat((short) value);
     }
 
-    // https://stackoverflow.com/a/6162687
-    // TODO: Replace with Float#floatToFloat16 once requires Java 21
     public static int floatToHalf(float value) {
-        int bits = Float.floatToIntBits(value);
-        int sign = bits >>> 16 & 0x8000;
-        int val = (bits & 0x7fffffff) + 0x1000;
-
-        if (val >= 0x47800000) {
-            if ((bits & 0x7fffffff) >= 0x47800000) {
-                if (val < 0x7f800000) {
-                    return sign | 0x7c00;
-                } else {
-                    return sign | 0x7c00 | (bits & 0x007fffff) >>> 13;
-                }
-            } else {
-                return sign | 0x7bff;
-            }
-        }
-
-        if (val >= 0x38800000) {
-            return sign | val - 0x38000000 >>> 13;
-        } else if (val < 0x33000000) {
-            return sign;
-        } else {
-            val = (bits & 0x7fffffff) >>> 23;
-            return sign | ((bits & 0x7fffff | 0x800000) + (0x800000 >>> val - 102) >>> 126 - val);
-        }
+        return Float.floatToFloat16(value);
     }
 
-    // TODO: Replace with Math#clamp once requires Java 21
     public static float clamp(float value, float min, float max) {
-        return Math.max(Math.min(value, max), min);
+        return Math.clamp(value, min, max);
     }
 
-    // TODO: Replace with Math#clamp once requires Java 21
     public static int clamp(int value, int min, int max) {
-        return Math.max(Math.min(value, max), min);
+        return Math.clamp(value, min, max);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <module>decima-ext-texture-viewer</module>
         <module>decima-model</module>
         <module>decima-ui</module>
+        <module>decima-help</module>
         <module>platform-model</module>
         <module>platform-ui</module>
     </modules>


### PR DESCRIPTION
## Summary
- fix README link to the Java 24 release page
- add a simple `BufferedImageProvider` to import standard images
- wire up texture import menu item
- modernize `MathUtils` and tidy imports
- add offline help viewer with bundled wiki pages
- document the built-in help feature

## Testing
- `./mvnw -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6854917001948332a6e41a7fde4993ac